### PR TITLE
Automates the recovery sequence of a review_app

### DIFF
--- a/awakener_script.rb
+++ b/awakener_script.rb
@@ -1,0 +1,24 @@
+require 'platform-api'
+
+system("curl -s https://cli-assets.heroku.com/heroku-cli/channels/stable/heroku-cli-linux-x64.tar.gz | tar -zx && mv heroku-cli* heroku-client")
+ENV["PATH"] = "/app/heroku-client/bin:#{ENV["PATH"]}"
+
+def restore_db(heroku_app_name)
+  puts "rescue #{heroku_app_name}"
+  system "heroku maintenance:on -a #{heroku_app_name}"
+  puts "maintenance ON"
+  system "heroku pg:backups:capture -a #{heroku_app_name}"
+  puts "backups:capture ok"
+  system "heroku pg:backups:restore -a #{heroku_app_name} --confirm #{heroku_app_name}"
+  puts "backups:restore ok"
+  system "heroku maintenance:off -a #{heroku_app_name}"
+  puts "maintenance OFF"
+end
+
+# WARNING : ENV['HEROKU_API_KEY'] is certainly not reachable from outside of Sirac Repository
+heroku_withAPIkey = PlatformAPI.connect(ENV['HEROKU_API_KEY'])
+review_apps = heroku_withAPIkey.app.list.select{ |app| app["name"].include?("sirac-staging-pr-") }.map{ |app| app["name"] }
+puts "#{review_apps.count} review apps detected"
+
+review_apps.each { |app_name| restore_db(app_name) }
+puts "the end"


### PR DESCRIPTION
Purpose of this PR is to allow Heroku scheduler to launch a sustainability sequence every day on every review app: 

- Each review_app's name is captured with `platform_api`, and stored in a array called `review_apps`
- Method `restore_db(heroku_app_name)` launch sustainability sequence.
- This ruby file is set to be launched every day with heroku scheduler
 