### PR TITLE
require platform-api

### DIFF
--- a/awakener_script.rb
+++ b/awakener_script.rb
@@ -1,3 +1,5 @@
+require "platform-api"
+
 system("curl -s https://cli-assets.heroku.com/heroku-cli/channels/stable/heroku-cli-linux-x64.tar.gz | tar -zx && mv heroku-cli* heroku-client")
 ENV["PATH"] = "/app/heroku-client/bin:#{ENV["PATH"]}"
 
@@ -19,4 +21,6 @@ review_apps = heroku_withAPIkey.app.list.select{ |app| app["name"].include?("sir
 puts "#{review_apps.count} review apps detected"
 
 review_apps.each { |app_name| puts "#{app_name} has to be restored" }
+# review_apps.each { |app_name| restore_db(app_name) }
+
 puts "the end"


### PR DESCRIPTION
Purpose of this app is only to lauch `ruby awakener_script.rb` .
Thus, even if `platform-api` is referenced in Gemfile, we need to  require this gem in the script `awakener_script.rb`