### PR TITLE
Create parent apps indexer

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,6 +13,9 @@
       "required": true
     }
   },
+  "scripts": {
+    "configure": "cat scripts/parent_apps_indexer.rb | heroku run console"
+  },
   "buildpacks": [
     {
       "url": "https://github.com/heroku/heroku-buildpack-cli"

--- a/scripts/parent_apps_indexer.rb
+++ b/scripts/parent_apps_indexer.rb
@@ -1,0 +1,9 @@
+require "platform-api"
+
+def indexer
+  PlatformAPI.connect(ENV["HEROKU_API_KEY"]).app.list.map do |app|
+    app["name"] if app["name"].end_with?("-staging")
+  end.compact
+end
+
+indexer


### PR DESCRIPTION
After creation of this app thanks to heroku button, we'd like to help user to list all possible parent apps.

This can done thanks to platform-api, and ruby file `scripts/parent_apps_indexer.rb`:

User can type as command line:
`cat scripts/parent_apps_indexer.rb | heroku run console -a $USER_APP_NAME --no-tty` , which could be launched by command line `heroku run configure -a $USER_APP_NAME`
